### PR TITLE
Fix title for gui3.tut

### DIFF
--- a/problem_db/gui3.tut/description.html
+++ b/problem_db/gui3.tut/description.html
@@ -1,4 +1,4 @@
-<h3>GUI Layout Example II</h3>
+<h3>GUI Layout Example III</h3>
 <p>
     We're continuing the theme of laying out buttons in a frame.
     In this question, you'll need to add fixed spacing between your widgets.


### PR DESCRIPTION
Previously, the title said "GUI Layout Example II". This is just a one-line fix for that.