### PR TITLE
Fixed problem with fill/expand in gui3

### DIFF
--- a/problem_db/gui3.tut/analysis.py
+++ b/problem_db/gui3.tut/analysis.py
@@ -69,7 +69,7 @@ class Analyser(CodeAnalyser):
                 self.add_error(
                     'You seem to be using the incorrect value for pack '
                     '(have {}, but should be tk.BOTH)'.format(
-                        child_frame_pack.keywords['expand']
+                        child_frame_pack.keywords['fill']
                     )
                 )
 


### PR DESCRIPTION
Currently errors out if a student doesn't have expand defined.