### PR TITLE
fix check + online menu

### DIFF
--- a/code/MyPyTutor.py
+++ b/code/MyPyTutor.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import sys
 from argparse import ArgumentParser
 
-ALLOWED_VERSIONS = [(3, 5), (3, 4)]
+ALLOWED_VERSIONS = [(3,6)]  #[(3, 5), (3, 4)]
 
 if sys.version_info.major == 3:
     from getpass import getpass

--- a/code/tutorlib/gui/editor/bindings.py
+++ b/code/tutorlib/gui/editor/bindings.py
@@ -19,8 +19,8 @@
 ## This define menus in the code edit window
 ## It is a modification of idlelib/Bindings.py
 
-from idlelib.configHandler import idleConf
-from idlelib import macosxSupport
+from idlelib.config import idleConf
+from idlelib import macosx
 
 menudefs = [
  # underscore prefixes character to underscore

--- a/code/tutorlib/gui/editor/editor_window.py
+++ b/code/tutorlib/gui/editor/editor_window.py
@@ -44,11 +44,10 @@ class TutorEditor(editor.EditorWindow):
         ("help", "_Help"),
     ]
 
-    Bindings = Bindings
+    mainmenu = Bindings
 
     def __init__(self, menu_delegate, editor_delegate, flist=None, root=None,
                  filename=None, online=False):
-
         # Support for Python >= 2.7.7 (TODO find a better way)
 		# Changes for Python 3.6
 		# The library macosxSupport was changed to macosx

--- a/code/tutorlib/gui/editor/editor_window.py
+++ b/code/tutorlib/gui/editor/editor_window.py
@@ -32,7 +32,7 @@ from tutorlib.utils.fonts import FIXED_FONT
 import tutorlib.utils.messagebox as tkmessagebox
 
 
-class TutorEditor(EditorWindow.EditorWindow):
+class TutorEditor(editor.EditorWindow):
     menu_specs = [
         ("file", "_File"),
         ("edit", "_Edit"),


### PR DESCRIPTION
The variable "Bindings" has been changed to "mainmenu"  in idlelib/EditorWindow.py in 3.6, hence the menu wasn't being populated. So I have changed the constant in the TutorEditor class and renamed some import statements to work with 3.6