### PR TITLE
revert button readded

### DIFF
--- a/code/tutorlib/gui/editor/editor_window.py
+++ b/code/tutorlib/gui/editor/editor_window.py
@@ -102,7 +102,7 @@ class TutorEditor(editor.EditorWindow):
         self.text.tag_config("orange", background="orange")
 
         self.tutorial = None
-        self.menudict['file'].delete(0, 1)  # TODO: huh?
+        self.menudict['file'].delete(0)  # TODO: huh?
 
     ## Menu Callbacks
     # file


### PR DESCRIPTION
I don't know why the revert button was removed, but I have re-added back. It allows student revert the problem to the original state to begin with.