### PR TITLE
Add HiDPI awareness to Tkinter window

### DIFF
--- a/code/MyPyTutor.py
+++ b/code/MyPyTutor.py
@@ -2,6 +2,10 @@
 from __future__ import print_function
 import sys
 from argparse import ArgumentParser
+import ctypes
+
+if hasattr(ctypes, 'windll'):
+    ctypes.windll.shcore.SetProcessDpiAwareness(1)
 
 ALLOWED_VERSIONS = [(3,6)]  #[(3, 5), (3, 4)]
 


### PR DESCRIPTION
Tkinter by default on windows machines with HiDPI screens is unaware of it, leading to larger elements and blurry font rendering. This checks if the machine is a windows machine (if `ctype` has the `windll` attribute) and sets Tkinter to be HiDPI aware, making everything a nicer size and fonts crisp.

Tested on Windows 10, Debian and elementary OS

![image](https://user-images.githubusercontent.com/28722943/31858625-7a1eb9b4-b73f-11e7-8da1-3ee5db3f4254.png)

![image](https://user-images.githubusercontent.com/28722943/31858627-97ce6a2c-b73f-11e7-993b-e9bf1b52a96d.png)

 